### PR TITLE
fix: handle cookies with an empty value

### DIFF
--- a/cookiestxt.go
+++ b/cookiestxt.go
@@ -74,7 +74,9 @@ func Parse(rd io.Reader) (cl []*http.Cookie, err error) {
 // ParseLine parse single cookie from one line
 func ParseLine(raw string) (c *http.Cookie, err error) {
 	f := strings.Fields(raw)
-	if len(f) < fieldsCount {
+	if len(f) == fieldsCount-1 {
+		f = append(f, "")
+	} else if len(f) < fieldsCount {
 		err = fmt.Errorf("expecting fields=7, got=%d", len(f))
 		return
 	}

--- a/cookiestxt_test.go
+++ b/cookiestxt_test.go
@@ -25,6 +25,15 @@ func ExampleParse() {
 	// Output: Name[0]=NETSCAPE_ID, Value[0]=100105, Len=1
 }
 
+func TestParseEmptyValue(t *testing.T) {
+	bt := time.Unix(946684799, 0)
+	c, err := ParseLine(".netscape.com TRUE / TRUE 946684799 NETSCAPE_ID ")
+	if err != nil || c.Value != "" || c.Expires.Before(bt) || !c.Secure {
+		t.Error(err)
+	}
+	t.Log(c)
+}
+
 func TestParseLine(t *testing.T) {
 	bt := time.Unix(946684799, 0)
 	c, err := ParseLine(".netscape.com TRUE / TRUE 946684799 NETSCAPE_ID 100103")


### PR DESCRIPTION
`strings.Fields` omits the empty trailing field on cookies with a blank value.